### PR TITLE
Update EventBusSubscriber annotation in QFComponents

### DIFF
--- a/src/main/java/de/cadentem/quality_food/registry/QFComponents.java
+++ b/src/main/java/de/cadentem/quality_food/registry/QFComponents.java
@@ -14,7 +14,7 @@ import net.neoforged.neoforge.registries.DataPackRegistryEvent;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
-@EventBusSubscriber
+@EventBusSubscriber(modid = QualityFood.MODID, bus = EventBusSubscriber.Bus.MOD)
 public class QFComponents {
     public static final ResourceKey<Registry<QualityType>> QUALITY_TYPE_REGISTRY = ResourceKey.createRegistryKey(QualityFood.location("quality_types"));
     public static final DeferredRegister.DataComponents REGISTRAR = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, QualityFood.MODID);


### PR DESCRIPTION
This event is a mod bus event, not a neoforge event. 

```java
public abstract class DataPackRegistryEvent extends Event implements IModBusEvent
```

My compat mod is crashing when trying to use this version as a dependency from this. It's a quick fix!